### PR TITLE
Fix build script on Windows

### DIFF
--- a/parallel-downloads/init.gradle
+++ b/parallel-downloads/init.gradle
@@ -11,7 +11,7 @@ if (!mirror.exists() || mirror.list().length==0 ) {
          def cache = rootProject.file("${gradle.gradleUserHomeDir}/caches/modules-2/files-2.1")
          cache.eachFileRecurse { f ->
             if (f.name.endsWith('.pom')) {
-                def parts = f.absolutePath.split(File.separator)
+                def parts = f.absolutePath.split(/\\|\//)
                 def (group, artifact, version) = [parts[-5], parts[-4], parts[-3]]
                 def targetDir = rootProject.file("${mirror.absolutePath}/${group.replace('.', File.separator)}/$artifact/$version")
                 println "Mirroring $group:$artifact:$version into $targetDir.absolutePath"


### PR DESCRIPTION
The current script actually can't work on Windows because
split() expects a regex. With current code, Java complains

```
java.util.regex.PatternSyntaxException: Unexpected internal error near index 1
\
 ^
```

Thus we fix the issue by plain regex literal.