### PR TITLE
Add gradle.properties to performance tests

### DIFF
--- a/exclude-merging/gradle.properties
+++ b/exclude-merging/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xms800m -Xmx800m
+org.gradle.workers.max=8
+org.gradle.parallel=true

--- a/parallel-downloads/gradle.properties
+++ b/parallel-downloads/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xms1g -Xmx1g
+org.gradle.workers.max=8
+org.gradle.parallel=true


### PR DESCRIPTION
so it is obvious with which memory settings they should be invoked.

We want to make sure that the performance projects used by the performance test in gradle/gradle declare the memory settings and parallelism in their `gradle.properties` file, so anybody running the test from the command line would use the same setting.